### PR TITLE
Add cursor-skills to README projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@
 
 ## Scripts
 
+- **[cursor-skills](https://github.com/gardusig/cursor-skills):** sync Cursor IDE agent skills between `~/.cursor` and the repo
 - **[gas-toolbox](https://github.com/gardusig/gas-toolbox):** to use Google workspace through Apps Script utility functions
 - **[tampermonkey](https://github.com/gardusig/tampermonkey):** to enhance or customize websites through JavaScript programs


### PR DESCRIPTION
## Summary

Add cursor-skills to the Projects section of the README, linking to the repo that syncs Cursor IDE agent skills between `~/.cursor` and the repo.

## 📝 Modified (1)

- `README.md` — add cursor-skills to projects list

Made with [Cursor](https://cursor.com)